### PR TITLE
fix(docker): reduce echidna service start period and update timestamp…

### DIFF
--- a/bot/docker-compose-prod.yml
+++ b/bot/docker-compose-prod.yml
@@ -16,7 +16,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 45s
+      start_period: 10s
   echidna:
     build: .
     depends_on:

--- a/bot/src/commands/admin/echidna-info.ts
+++ b/bot/src/commands/admin/echidna-info.ts
@@ -62,7 +62,7 @@ export default class EchidnaInfoCommand extends Command<typeof options> {
 				.setThumbnail(image ?? null)
 				.setColor(color as RGBTuple)
 				.setFooter({
-					text: `Echidna ID: ${config.DISCORD_DB_PROFILE} - Commit Hash: ${config.SOURCE_COMMIT} - Created at: ${dayjs(echidna.createdAt).format("DD/MM/YYYY HH:mm:ss")}`,
+					text: `Echidna ID: ${config.DISCORD_DB_PROFILE} - Commit Hash: ${config.SOURCE_COMMIT} - Created at: ${dayjs(this.echidna.user?.createdAt).format("DD/MM/YYYY HH:mm:ss")}`,
 				})
 				.addFields([
 					{


### PR DESCRIPTION
… in echidna-info footer

- Changed the start period for the echidna service in the Docker Compose file from 45s to 10s for quicker startup.
- Updated the footer in the Echidna info command to correctly display the creation timestamp of the user associated with the echidna.