### PR TITLE
fix(docker): update echidna service healthcheck URL and adjust start …

### DIFF
--- a/bot/docker-compose-prod.yml
+++ b/bot/docker-compose-prod.yml
@@ -12,11 +12,11 @@ services:
       - OPENVPN_USER=${OPENVPN_USER}
       - OPENVPN_PASSWORD=${OPENVPN_PASSWORD}
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://google.com"]
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "https://one.one.one.one"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 10s
+      start_period: 45s
   echidna:
     build: .
     depends_on:


### PR DESCRIPTION
…period

- Changed the healthcheck URL for the echidna service from http://google.com to https://one.one.one.one for improved reliability.
- Increased the start period for the echidna service from 10s to 45s to allow for better initialization.